### PR TITLE
Change version of build tools

### DIFF
--- a/jsevaluator/build.gradle
+++ b/jsevaluator/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 22
-    buildToolsVersion "23.0.0 rc2"
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 15


### PR DESCRIPTION
It looks like the version 23.0.0 rc2 doesn't exist anymore. I changed it to the last one I found in my SDK manager for 23